### PR TITLE
Fix code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "express": "^4.21.2",
     "mongodb": "3.7",
     "mongoose": "^6.13.5",
-    "morgan": "^1.10.0"
+    "morgan": "^1.10.0",
+    "express-rate-limit": "^7.5.0"
   },
   "devDependencies": {
     "nodemon": "^2.0.22"

--- a/server.js
+++ b/server.js
@@ -8,11 +8,17 @@ const db = require('./db/connection')
 const Trail = require('./models/trail')
 const app = express()
 
+const RateLimit = require('express-rate-limit');
+const limiter = RateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // max 100 requests per windowMs
+});
 
 app.use(cors())
 app.use(bodyParser.json())
 // app.use(express.json());
 app.use(logger('dev'))
+app.use(limiter)
 
 db.on('error', console.error.bind(console, 'MongoDB connection error:'))
 


### PR DESCRIPTION
Fixes [https://github.com/Darnycya/escape-nyc-api/security/code-scanning/1](https://github.com/Darnycya/escape-nyc-api/security/code-scanning/1)

To fix the problem, we need to introduce rate limiting to the Express application. The best way to do this is by using the `express-rate-limit` package, which allows us to set a maximum number of requests that can be made to the server within a specified time window. This will help prevent abuse and protect the server from being overwhelmed by too many requests.

We will:
1. Install the `express-rate-limit` package.
2. Set up a rate limiter with a reasonable configuration.
3. Apply the rate limiter to all routes in the application.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
